### PR TITLE
Xenial Packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 dist: trusty
 env:
   matrix:
-    - DIST=precise
+    - DIST=xenial
     - DIST=trusty
 before_install:
   - sudo apt-get -y install wget software-properties-common
@@ -13,6 +13,7 @@ before_install:
 before_script:
   - make clean
 script:
+  - sed -i "s:trusty:${DIST}:g" debian/changelog
   - make
 before_deploy:
   - make deb

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ env:
     - DIST=trusty
 before_install:
   - sudo apt-get -y install wget software-properties-common
-  - sudo add-apt-repository -y "deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main 9.6" && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-  - sudo apt-get update && sudo apt-get -y install postgresql-server-dev-all postgresql-server-dev-9.6 devscripts rsync build-essential dh-make libkrb5-dev
-  - echo '9.1\n9.2\n9.3\n9.4\n9.5\n9.6' > ~/.pg_supported_versions
+  - sudo add-apt-repository -y "deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main" && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+  - sudo apt-get update && sudo apt-get -y install postgresql-server-dev-all devscripts rsync build-essential dh-make libkrb5-dev
+  - echo '9.3\n9.4' > ~/.pg_supported_versions
 before_script:
   - make clean
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,13 @@ env:
     - DIST=xenial
     - DIST=trusty
 before_install:
+  - psql --version
+  - sudo /etc/init.d/postgresql stop
+  - sudo apt-get -y --purge remove postgresql libpq-dev libpq5 postgresql-client-common postgresql-common
+  - sudo rm -rf /var/lib/postgresql
   - sudo apt-get -y install wget software-properties-common
   - sudo add-apt-repository -y "deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main" && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-  - sudo apt-get update && sudo apt-get -y install postgresql-server-dev-all devscripts rsync build-essential dh-make libkrb5-dev
+  - sudo apt-get update && sudo apt-get -y install postgresql-server-dev-9.4 postgresql-server-dev-9.3 devscripts rsync build-essential dh-make libkrb5-dev libssl-dev
   - echo '9.3\n9.4' > ~/.pg_supported_versions
 before_script:
   - make clean

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
   - sudo rm -rf /var/lib/postgresql
   - sudo apt-get -y install wget software-properties-common
   - sudo add-apt-repository -y "deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main" && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-  - sudo apt-get update && sudo apt-get -y install postgresql-server-dev-all devscripts rsync build-essential dh-make libkrb5-dev libssl-dev
+  - sudo apt-get update && sudo apt-get -y install postgresql-server-dev-9.3 postgresql-server-dev-9.4 devscripts rsync build-essential dh-make libkrb5-dev libssl-dev
   - echo '9.3\n9.4' > ~/.pg_supported_versions
 before_script:
   - make clean
@@ -20,6 +20,7 @@ script:
   - sed -i "s:trusty:${DIST}:g" debian/changelog
   - make
 before_deploy:
+  - sudo apt-get -y install postgresql-server-dev-all
   - make deb
 deploy:
   provider: packagecloud

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
   - sudo rm -rf /var/lib/postgresql
   - sudo apt-get -y install wget software-properties-common
   - sudo add-apt-repository -y "deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main" && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-  - sudo apt-get update && sudo apt-get -y install postgresql-server-dev-9.4 postgresql-server-dev-9.3 devscripts rsync build-essential dh-make libkrb5-dev libssl-dev
+  - sudo apt-get update && sudo apt-get -y install postgresql-server-dev-all devscripts rsync build-essential dh-make libkrb5-dev libssl-dev
   - echo '9.3\n9.4' > ~/.pg_supported_versions
 before_script:
   - make clean

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-pgsslstatus (1.0-1heroku1) precise; urgency=medium
+pgsslstatus (1.0-1heroku1) trusty; urgency=medium
 
   * Initial release
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+pgsslstatus (1.0-1heroku2) trusty; urgency=medium
+
+  * Release for package autobuilding
+
+ -- Greg Burek <gburek@salesforce.com>  Fri, 16 Feb 2018 01:05:56 +0000
+
 pgsslstatus (1.0-1heroku1) trusty; urgency=medium
 
   * Initial release

--- a/debian/control
+++ b/debian/control
@@ -10,26 +10,6 @@ Vcs-Git: https://github.com/heroku/pg_sslstatus.git
 Vcs-Browser: https://github.com/heroku/pg_sslstatus
 XS-Testsuite: autopkgtest
 
-Package: postgresql-9.1-pgsslstatus
-Section: libs
-Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, postgresql-9.1
-Description: PostgreSQL SSL Status
- pg_sslstatus is a simple extension to PostgreSQL that allows an administrator
- to view the SSL status of different connections. It shows whether SSL is in
- force, the negotiated SSL parameters, and information about the (optional)
- client certificate on the connection.
-
-Package: postgresql-9.2-pgsslstatus
-Section: libs
-Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, postgresql-9.2
-Description: PostgreSQL SSL Status
- pg_sslstatus is a simple extension to PostgreSQL that allows an administrator
- to view the SSL status of different connections. It shows whether SSL is in
- force, the negotiated SSL parameters, and information about the (optional)
- client certificate on the connection.
-
 Package: postgresql-9.3-pgsslstatus
 Section: libs
 Architecture: any
@@ -44,26 +24,6 @@ Package: postgresql-9.4-pgsslstatus
 Section: libs
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, postgresql-9.4
-Description: PostgreSQL SSL Status
- pg_sslstatus is a simple extension to PostgreSQL that allows an administrator
- to view the SSL status of different connections. It shows whether SSL is in
- force, the negotiated SSL parameters, and information about the (optional)
- client certificate on the connection.
-
-Package: postgresql-9.5-pgsslstatus
-Section: libs
-Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, postgresql-9.5
-Description: PostgreSQL SSL Status
- pg_sslstatus is a simple extension to PostgreSQL that allows an administrator
- to view the SSL status of different connections. It shows whether SSL is in
- force, the negotiated SSL parameters, and information about the (optional)
- client certificate on the connection.
-
-Package: postgresql-9.6-pgsslstatus
-Section: libs
-Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, postgresql-9.6
 Description: PostgreSQL SSL Status
  pg_sslstatus is a simple extension to PostgreSQL that allows an administrator
  to view the SSL status of different connections. It shows whether SSL is in


### PR DESCRIPTION
This pr only builds packages for 9.3 and 9.4, as 9.5+ has pg_stat_ssl. This PR also now builds packages for xenial. 